### PR TITLE
add cart_products_id attribute to Cart::Product

### DIFF
--- a/lib/Interchange6/Cart/Product.pm
+++ b/lib/Interchange6/Cart/Product.pm
@@ -22,6 +22,17 @@ Each cart product has the following attributes:
 
 =over 4
 
+=item cart_products_id
+
+Can be used by subclasses to tie cart products to L<Interchange6::Schema::Result::CartProduct>.
+
+=cut
+
+has cart_products_id => (
+    is => 'ro',
+    isa => Int,
+);
+
 =item sku
 
 Unique product identifier is required.


### PR DESCRIPTION
expose cart_products_id to enable DPIC6 to safely tie cart products to schema
