### PR TITLE
clean-up imports by using namespace::clean last

### DIFF
--- a/lib/Interchange6/Cart.pm
+++ b/lib/Interchange6/Cart.pm
@@ -14,14 +14,13 @@ use DateTime;
 use Interchange6::Cart::Product;
 use Scalar::Util 'blessed';
 use Try::Tiny;
-use Moo;
-use MooseX::CoverableModifiers;
-use MooX::HandlesVia;
-use Types::Standard qw/ArrayRef InstanceOf Str/;
 use Types::Common::String qw/NonEmptyStr/;
+use Types::Standard qw/ArrayRef InstanceOf Str/;
 
+use Moo;
+use MooX::HandlesVia;
+use MooseX::CoverableModifiers;
 with 'Interchange6::Role::Costs';
-
 use namespace::clean;
 
 =head1 DESCRIPTION

--- a/lib/Interchange6/Cart/Cost.pm
+++ b/lib/Interchange6/Cart/Cost.pm
@@ -3,10 +3,10 @@
 package Interchange6::Cart::Cost;
 
 use strict;
-use Moo;
-use Types::Standard qw/Bool Defined Int Num/;
 use Types::Common::String qw/NonEmptyStr/;
+use Types::Standard qw/Bool Defined Int Num/;
 
+use Moo;
 use namespace::clean;
 
 =head1 NAME 

--- a/lib/Interchange6/Cart/Product.pm
+++ b/lib/Interchange6/Cart/Product.pm
@@ -3,14 +3,14 @@
 package Interchange6::Cart::Product;
 
 use strict;
-use Moo;
-use MooseX::CoverableModifiers;
-use MooX::HandlesVia;
-use Types::Standard qw/Defined HashRef HasMethods InstanceOf Int Maybe Num Str Undef/;
 use Types::Common::Numeric qw/PositiveInt PositiveOrZeroNum/;
 use Types::Common::String qw/NonEmptyStr/;
-with 'Interchange6::Role::Costs';
+use Types::Standard qw/Defined HashRef HasMethods InstanceOf Int Maybe Num Str Undef/;
 
+use Moo;
+use MooX::HandlesVia;
+use MooseX::CoverableModifiers;
+with 'Interchange6::Role::Costs';
 use namespace::clean;
 
 =head1 NAME 

--- a/lib/Interchange6/Role/Costs.pm
+++ b/lib/Interchange6/Role/Costs.pm
@@ -2,13 +2,14 @@
 
 package Interchange6::Role::Costs;
 
+use strict;
 use Interchange6::Cart::Cost;
 use Scalar::Util 'blessed';
-use Moo::Role;
-use MooseX::CoverableModifiers;
-use MooX::HandlesVia;
 use Types::Standard qw/ArrayRef InstanceOf Num/;
 
+use Moo::Role;
+use MooX::HandlesVia;
+use MooseX::CoverableModifiers;
 use namespace::clean;
 
 =head1 ATTRIBUTES


### PR DESCRIPTION
patch for issue#29, re-order imports so that use Moo* and use namespace::clean will come after all other imports