### PR TITLE
add attribute to allow products to, optionally, not be combined by SKU

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,7 @@ MANIFEST.SKIP
 README
 t/README
 t/00-base.t
+t/01-combine-by-sku.t
 t/author/manifest.t
 t/author/pod-coverage.t
 t/author/pod.t

--- a/lib/Interchange6/Cart.pm
+++ b/lib/Interchange6/Cart.pm
@@ -308,7 +308,7 @@ sub add {
 
     $index = $self->product_index( sub { $_->sku eq $product->sku } );
 
-    if ( $index >= 0 ) {
+    if ( $index >= 0 && $product->should_combine_by_sku ) {
 
         # product already exists in cart so we need to add new quantity to old
 

--- a/lib/Interchange6/Cart/Product.pm
+++ b/lib/Interchange6/Cart/Product.pm
@@ -5,7 +5,7 @@ package Interchange6::Cart::Product;
 use strict;
 use Types::Common::Numeric qw/PositiveInt PositiveOrZeroNum/;
 use Types::Common::String qw/NonEmptyStr/;
-use Types::Standard qw/Defined HashRef HasMethods InstanceOf Int Maybe Num Str Undef/;
+use Types::Standard qw/Bool CodeRef Defined HashRef HasMethods InstanceOf Int Maybe Num Str Undef/;
 
 use Moo;
 use MooX::HandlesVia;
@@ -257,6 +257,24 @@ has extra => (
     },
 );
 
+=head2 combine
+
+Indicate whether products with the same SKU should be combined in the Cart
+
+=over 
+
+=item Writer: C<combine>
+
+=back
+
+=cut
+   
+has combine => (
+    is      => 'ro',
+    isa     => CodeRef | Bool,
+    default => 1,
+);
+
 =head1 METHODS
 
 See also L<Interchange6::Role::Costs/METHODS>.
@@ -327,6 +345,27 @@ Returns 0 if L</canonical_sku> is defined else 1.
 
 sub is_canonical {
     return defined shift->canonical_sku ? 0 : 1;
+}
+
+=head2 should_combine_by_sku
+
+Determines whether a product should be combined by sku based on the 
+value of L</combine>.
+
+If L</combine> isa CodeRef the result of applying that CodeRef is returned
+otherwise:
+   Returns 0 if a product should not be combined
+   Returns 1 if a product should be combined
+
+=cut
+   
+sub should_combine_by_sku {
+   my ($self) = @_;
+
+   return $self->combine->()
+      if ref $self->combine eq 'CODE';
+
+   return $self->combine;
 }
 
 # after cost changes we need to clear the cart subtotal/total

--- a/t/01-combine-by-sku.t
+++ b/t/01-combine-by-sku.t
@@ -1,0 +1,54 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::More;
+
+use aliased 'Interchange6::Cart';
+use aliased 'Interchange6::Cart::Product';
+
+my ( $product1, $product2, $cart );
+
+lives_ok { $cart = Cart->new } "create new cart";
+
+lives_ok {
+   $cart->add( sku => "SKU01", name => "One", price => 10, quantity => 1 );
+}
+"1. add SKU01, One, price 10, qty 1";
+
+is( $cart->count, 1, 'only a single item in the Cart' );
+
+$product1 = $cart->product_get(0);
+is( $product1->combine, 1, 'combine set to 1 by default' );
+
+# add a product with the same SKU, but combine set to 0
+lives_ok {
+   $cart->add( sku => "SKU01", name => "One", price => 10, quantity => 1, combine => 0 );
+}
+"2. add SKU01, One, price 10, qty 1";
+
+$product2 = $cart->product_get(1);
+is( $cart->count, 2, 'two products now exist in the Cart' );
+is( $product1->sku, $product2->sku, 'both products in the Cart have the same sku' );
+
+# add a product with the same SKU, but with combine set to 1
+lives_ok {
+   $cart->add( sku => "SKU01", name => "One", price => 10, quantity => 1, combine => 1 );
+}
+"3. add SKU01, One, price 10, qty 1";
+
+is( $cart->count, 2, 'two products still exist in the Cart' );
+is( $cart->quantity, 3, 'quantity is now 3, two products with the same sku were combined' );
+
+# add a product with the same SKU, but with combine set to a custom CodeRef
+lives_ok {
+   $cart->add( sku => "SKU01", name => "One", price => 10, quantity => 1, combine => sub { return 0 }, );
+}
+"4. add SKU01, One, price 10, qty 1";
+
+is( $cart->count, 3, 'three products now exist in the Cart' );
+is( $cart->quantity, 4, 'quantity is now 4' );
+
+done_testing();


### PR DESCRIPTION
patch for issue #13:
- There is now a new attribute in lib/Interchange6/Cart/Product.pm called `combine` that accepts either a boolean value (0, 1) or a coderef.
- There is now logic in  lib/Interchange6/Cart.pm that examines the `combine` attribute _before_ merging a products in the Cart that have the same SKU.
- A new test, t/01-combine-by-sku.t tests all variations of values that can be passed to the `combine` attribute
